### PR TITLE
otel instrumentation

### DIFF
--- a/.env.secret.sample
+++ b/.env.secret.sample
@@ -1,0 +1,13 @@
+export ANTHROPIC_API_KEY=<your anthropic api key>
+export OPENAI_API_KEY=<your openai api key>
+
+# For (optional) instrumentation.  You can export spans to either honeycomb or the console.
+# If neither is enabled, no spans will be exported anywhere.
+
+# For honeycomb, uncomment these and fill in your api key:
+#
+# export HONEYCOMB_API_KEY=<your honeycomb api key>
+# export OTEL_EXPORTER_OTLP_ENDPOINT=https://api.honeycomb.io/v1/traces
+
+# For console, leave the honeycomb variables commented out and uncomment this:
+# export OTEL_CONSOLE_EXPORTER=1

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ coverage/
 # Environments
 .env
 .env.*
+!.env.secret.sample
 .venv
 .venv/
 

--- a/code-monkey/src/instrumentation/__init__.py
+++ b/code-monkey/src/instrumentation/__init__.py
@@ -1,0 +1,74 @@
+import functools
+import os
+from opentelemetry import trace
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource, Attributes
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace.export import (
+    BatchSpanProcessor,
+    ConsoleSpanExporter,
+)
+
+# re-export this from here so we don't have to litter the code with otel imports
+Tracer = trace.Tracer
+
+_tracer = None
+
+def tracer() -> Tracer:
+    global _tracer
+    return _tracer
+
+def set_tracer(tracer: Tracer):
+    global _tracer
+    _tracer = tracer
+
+def current_span() -> trace.Span:
+    return trace.get_current_span()
+
+# Creates a tracer from the global tracer provider
+def initialize_tracer(attributes: Attributes = None):
+    service_resource = Resource.create({
+        SERVICE_NAME: "ai_playground",
+    })
+
+    extra_resource = Resource.get_empty() if attributes is None else Resource.create(attributes)
+
+    exporter = None
+    if os.getenv("HONEYCOMB_API_KEY") is not None and os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT") is not None:
+        # TODO(toshok): this is for grpc, which I'd love to use, but doesn't seem to work?
+        # exporter = OTLPSpanExporter(
+        #     endpoint=os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT"),
+        #     headers=(("x-honeycomb-team", os.getenv("HONEYCOMB_API_KEY"))),
+        # )
+        exporter = OTLPSpanExporter(
+            endpoint=os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT"),
+            headers={
+                "x-honeycomb-team": os.getenv("HONEYCOMB_API_KEY"),
+            },
+        )
+    elif os.getenv("OTEL_CONSOLE_EXPORTER"):
+        exporter = ConsoleSpanExporter()
+
+    if exporter is None:
+        provider = trace.NoOpTracerProvider()
+    else:
+        provider = TracerProvider(
+            resource=extra_resource.merge(service_resource)
+        )
+        processor = BatchSpanProcessor(exporter)
+        provider.add_span_processor(processor)
+
+    # Sets the global default tracer provider
+    trace.set_tracer_provider(provider)
+
+    set_tracer(trace.get_tracer("replayio.ai-playground"))
+
+
+def instrument(name: str, attributes=None):
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            with tracer().start_as_current_span(name, attributes=attributes):
+                return func(*args, **kwargs)
+        return wrapper
+    return decorator

--- a/code-monkey/src/main.py
+++ b/code-monkey/src/main.py
@@ -1,13 +1,19 @@
 
+from uuid import uuid4, UUID
 from agents.agents import Coder
 from constants import load_environment
+from models import Claude
+from instrumentation import instrument, initialize_tracer
 
+# NB(toshok) this starts the root span for a given conversation involving
+# potentionally multiple agents and possibly several prompts per agent.  In a
+# agent-as-process model, this would instead be the request handler for the
+# agent.
+@instrument("main")
 def main() -> None:
     print("Initializing...")
 
-    load_environment()
-
-    coder = Coder()
+    coder = Coder(Claude)
     coder.initialize()
 
     print("Go...\n")
@@ -17,4 +23,10 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    load_environment()
+
+    initialize_tracer({
+        "agent": "Coder",
+    });
+
     main()

--- a/code-monkey/src/token_stats.py
+++ b/code-monkey/src/token_stats.py
@@ -3,6 +3,7 @@ from collections import deque, Counter
 from constants import CLAUDE_RATE_LIMIT
 from anthropic.types import ContentBlock
 from typing import List
+from instrumentation import tracer
 
 TOP_N = 5
 
@@ -50,7 +51,9 @@ class TokenStats:
                 print(
                     f"💤 Rate limit reached ({tokens_in_last_minute}/min). Sleeping for {sleep_time:.2f} seconds..."
                 )
-                time.sleep(sleep_time)
+                with tracer().start_as_current_span("rate_limit_avoidance") as span:
+                    span.set_attribute("tokens_in_last_minute", tokens_in_last_minute)
+                    time.sleep(sleep_time)
 
     def print_stats(self):
         print("\nToken Statistics:")

--- a/code-monkey/src/tools/ask_user_tool.py
+++ b/code-monkey/src/tools/ask_user_tool.py
@@ -1,5 +1,6 @@
 from typing import Dict, Any
 from .tool import Tool
+from instrumentation import instrument
 
 class AskUserTool(Tool):
     name = "ask_user"
@@ -15,6 +16,7 @@ class AskUserTool(Tool):
         "required": ["prompt"],
     }
 
+    @instrument("handle_tool_call", attributes={ "tool": "AskUserTool" })
     def handle_tool_call(self, input: Dict[str, Any]) -> Dict[str, Any] | None:
         prompt = input["prompt"]
         print(prompt)

--- a/code-monkey/src/tools/create_file_tool.py
+++ b/code-monkey/src/tools/create_file_tool.py
@@ -2,6 +2,7 @@ import os
 from typing import Dict, Any
 from .io_tool import IOTool
 from .utils import make_file_path
+from instrumentation import instrument
 
 class CreateFileTool(IOTool):
     name = "create_file"
@@ -21,6 +22,7 @@ class CreateFileTool(IOTool):
         "required": ["fname"],
     }
 
+    @instrument("handle_tool_call", attributes={ "tool": "CreateFileTool" })
     def handle_tool_call(self, input: Dict[str, Any]) -> Dict[str, Any] | None:
         name = input["fname"]
         content = input.get("content", "")

--- a/code-monkey/src/tools/delete_file_tool.py
+++ b/code-monkey/src/tools/delete_file_tool.py
@@ -2,6 +2,7 @@ import os
 from typing import Dict, Any
 from .io_tool import IOTool
 from .utils import make_file_path
+from instrumentation import instrument
 
 class DeleteFileTool(IOTool):
     name = "delete_file"
@@ -17,6 +18,7 @@ class DeleteFileTool(IOTool):
         "required": ["fname"],
     }
 
+    @instrument("handle_tool_call", attributes={ "tool": "DeleteFileTool" })
     def handle_tool_call(self, input: Dict[str, Any]) -> Dict[str, Any] | None:
         name = input["fname"]
         file_path = make_file_path(name)

--- a/code-monkey/src/tools/exec_tool.py
+++ b/code-monkey/src/tools/exec_tool.py
@@ -4,6 +4,7 @@ from typing import Dict, Any
 from .tool import Tool
 from .utils import get_file_tree, ask_user
 from constants import artifacts_dir
+from instrumentation import instrument
 
 # Set to store approved commands
 approved_commands = set()
@@ -19,6 +20,7 @@ class ExecTool(Tool):
         "required": ["command"],
     }
 
+    @instrument("handle_tool_call", attributes={ "tool": "ExecTool" })
     def handle_tool_call(self, input: Dict[str, Any]) -> Dict[str, Any] | None:
         command = input["command"]
         file_tree = get_file_tree(artifacts_dir)

--- a/code-monkey/src/tools/get_dependencies_tool.py
+++ b/code-monkey/src/tools/get_dependencies_tool.py
@@ -3,6 +3,7 @@ from typing import Dict, Any
 from .tool import Tool
 from deps.deps import DependencyGraph
 from constants import artifacts_dir
+from instrumentation import instrument
 
 
 class GetDependenciesTool(Tool):
@@ -20,6 +21,7 @@ class GetDependenciesTool(Tool):
         "required": ["module_names"],
     }
 
+    @instrument("handle_tool_call", attributes={ "tool": "GetDependenciesTool" })
     def handle_tool_call(self, input: Dict[str, Any]) -> Dict[str, Any] | None:
         module_names = input["module_names"]
         module_paths = [

--- a/code-monkey/src/tools/invoke_agent_tool.py
+++ b/code-monkey/src/tools/invoke_agent_tool.py
@@ -1,6 +1,7 @@
 from typing import Dict, Any, List
 from pydantic import BaseModel, Field
 from .tool import Tool
+from instrumentation import instrument
 
 class InvokeAgentInput(BaseModel):
     agent_name: str = Field(..., description="Name of the agent to invoke")
@@ -18,6 +19,7 @@ class InvokeAgentTool(Tool):
         super().__init__()
         self.agent_names = agent_names
 
+    @instrument("handle_tool_call", attributes={ "tool": "InvokeAgentInput" })
     def handle_tool_call(self, input: Dict[str, Any]) -> str | None:
         from agents.agents import agents_by_name
         agent_name = input.get("agent_name")

--- a/code-monkey/src/tools/read_file_tool.py
+++ b/code-monkey/src/tools/read_file_tool.py
@@ -1,6 +1,7 @@
 from typing import Dict, Any
 from .io_tool import IOTool
 from .utils import make_file_path
+from instrumentation import instrument
 
 class ReadFileTool(IOTool):
     name = "read_file"
@@ -13,6 +14,7 @@ class ReadFileTool(IOTool):
         "required": ["fname"],
     }
 
+    @instrument("handle_tool_call", attributes={ "tool": "ReadFileTool" })
     def handle_tool_call(self, input: Dict[str, Any]) -> str | None:
         name = input["fname"]
         file_path = make_file_path(name)

--- a/code-monkey/src/tools/rename_file_tool.py
+++ b/code-monkey/src/tools/rename_file_tool.py
@@ -2,6 +2,7 @@ import os
 from typing import Dict, Any
 from .io_tool import IOTool
 from .utils import make_file_path
+from instrumentation import instrument
 
 class RenameFileTool(IOTool):
     name = "rename_file"
@@ -18,6 +19,7 @@ class RenameFileTool(IOTool):
         "required": ["old_name", "new_name"],
     }
 
+    @instrument("handle_tool_call", attributes={ "tool": "RenameFileTool" })
     def handle_tool_call(self, input: Dict[str, Any]) -> Dict[str, Any] | None:
         old_name = input["old_name"]
         new_name = input["new_name"]

--- a/code-monkey/src/tools/replace_in_file_tool.py
+++ b/code-monkey/src/tools/replace_in_file_tool.py
@@ -1,6 +1,7 @@
 from typing import Dict, Any
 from .io_tool import IOTool
 from .utils import make_file_path
+from instrumentation import instrument
 
 class ReplaceInFileTool(IOTool):
     name = "replace_in_file"
@@ -21,6 +22,7 @@ class ReplaceInFileTool(IOTool):
         "required": ["fname", "to_replace", "replacement"],
     }
 
+    @instrument("handle_tool_call", attributes={ "tool": "ReplaceInFileTool" })
     def handle_tool_call(self, input: Dict[str, Any]) -> Dict[str, Any] | None:
         name = input["fname"]
         to_replace = input["to_replace"]

--- a/code-monkey/src/tools/rg_tool.py
+++ b/code-monkey/src/tools/rg_tool.py
@@ -4,6 +4,7 @@ import os
 from typing import Dict, Any
 from .tool import Tool
 from constants import artifacts_dir
+from instrumentation import instrument
 
 class RgTool(Tool):
     name = "rg"
@@ -21,6 +22,7 @@ class RgTool(Tool):
         "required": ["pattern"],
     }
 
+    @instrument("handle_tool_call", attributes={ "tool": "RgTool" })
     def handle_tool_call(self, input: Dict[str, Any]) -> str:
         pattern = input["pattern"]
         logging.debug(f"artifacts_dir: {artifacts_dir}")

--- a/code-monkey/src/tools/run_test_tool.py
+++ b/code-monkey/src/tools/run_test_tool.py
@@ -3,6 +3,7 @@ import subprocess
 from typing import Dict, Any
 from .tool import Tool
 from .utils import make_file_path
+from instrumentation import instrument
 
 class RunTestTool(Tool):
     name = "run_test"
@@ -18,6 +19,7 @@ class RunTestTool(Tool):
         "required": ["fname"],
     }
 
+    @instrument("handle_tool_call", attributes={ "tool": "RunTestTool" })
     def handle_tool_call(self, input: Dict[str, Any]) -> Dict[str, Any] | None:
         name = input["fname"]
         file_path = make_file_path(name)

--- a/code-monkey/src/tools/tools.py
+++ b/code-monkey/src/tools/tools.py
@@ -1,6 +1,6 @@
 import traceback
 from typing import List, Dict, Set, Any, Type
-from enum import Enum
+from enum import StrEnum
 
 from tools.tool import Tool
 from tools.read_file_tool import ReadFileTool
@@ -17,9 +17,10 @@ from tools.io_tool import IOTool
 from tools.invoke_agent_tool import InvokeAgentTool
 
 
-class ModelName(Enum):
-    Openai = 1
-    Claude = 2
+class ModelName(StrEnum):
+    Noop = "noop"
+    Openai = "openai"
+    Claude = "claude"
 
 
 def get_tool_spec(tool_class: Tool) -> Dict[str, Any]:

--- a/code-monkey/src/tools/write_file_tool.py
+++ b/code-monkey/src/tools/write_file_tool.py
@@ -2,6 +2,7 @@ import os
 from typing import Dict, Any
 from .io_tool import IOTool
 from .utils import make_file_path
+from instrumentation import instrument
 
 class WriteFileTool(IOTool):
     name = "write_file"
@@ -18,6 +19,7 @@ class WriteFileTool(IOTool):
         "required": ["fname", "content"],
     }
 
+    @instrument("handle_tool_call", attributes={ "tool": "WriteFileTool" })
     def handle_tool_call(self, input: Dict[str, Any]) -> str | None:
         name = input["fname"]
         content = input["content"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,9 @@ authors = [
 ]
 dependencies = [
     "openai>=1.35.13",
+    "opentelemetry-api>=1.25.0",
+    "opentelemetry-sdk>=1.25.0",
+    "opentelemetry-exporter-otlp-proto-http>=1.25.0",
     "python-dotenv>=1.0.1",
     "langchain>=0.2.7",
     "langchain-community>=0.2.7",

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -51,6 +51,9 @@ dataclasses-json==0.6.7
     # via unstructured-client
 deepdiff==7.0.1
     # via unstructured-client
+deprecated==1.2.14
+    # via opentelemetry-api
+    # via opentelemetry-exporter-otlp-proto-http
 dill==0.3.8
     # via pylint
 distro==1.9.0
@@ -58,8 +61,6 @@ distro==1.9.0
     # via openai
 emoji==2.12.1
     # via unstructured
-evdev==1.7.1
-    # via pynput
 faiss-cpu==1.8.0.post1
     # via ai-playground
 filelock==3.15.4
@@ -72,6 +73,7 @@ frozenlist==1.4.1
 fsspec==2024.6.1
     # via huggingface-hub
 google-api-core==2.19.1
+    # via google-api-core
     # via google-cloud-speech
 google-auth==2.32.0
     # via ai-playground
@@ -82,14 +84,13 @@ google-cloud-speech==2.26.1
 googleapis-common-protos==1.63.2
     # via google-api-core
     # via grpcio-status
+    # via opentelemetry-exporter-otlp-proto-http
 graphviz==0.20.3
     # via ai-playground
-greenlet==3.0.3
-    # via sqlalchemy
 grpcio==1.65.1
     # via google-api-core
     # via grpcio-status
-grpcio-status==1.65.1
+grpcio-status==1.62.2
     # via google-api-core
 h11==0.14.0
     # via httpcore
@@ -107,6 +108,8 @@ idna==3.7
     # via requests
     # via unstructured-client
     # via yarl
+importlib-metadata==7.1.0
+    # via opentelemetry-api
 iniconfig==2.0.0
     # via pytest
 isort==5.13.2
@@ -172,6 +175,23 @@ numpy==1.26.4
 openai==1.35.13
     # via ai-playground
     # via langchain-openai
+opentelemetry-api==1.25.0
+    # via ai-playground
+    # via opentelemetry-exporter-otlp-proto-http
+    # via opentelemetry-sdk
+    # via opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.25.0
+    # via opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-http==1.25.0
+    # via ai-playground
+opentelemetry-proto==1.25.0
+    # via opentelemetry-exporter-otlp-proto-common
+    # via opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.25.0
+    # via ai-playground
+    # via opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.46b0
+    # via opentelemetry-sdk
 ordered-set==4.1.0
     # via deepdiff
 orjson==3.10.6
@@ -192,11 +212,12 @@ pluggy==1.5.0
 proto-plus==1.24.0
     # via google-api-core
     # via google-cloud-speech
-protobuf==5.27.2
+protobuf==4.25.3
     # via google-api-core
     # via google-cloud-speech
     # via googleapis-common-protos
     # via grpcio-status
+    # via opentelemetry-proto
     # via proto-plus
 psutil==6.0.0
     # via unstructured
@@ -219,6 +240,23 @@ pylint==3.2.5
     # via ai-playground
 pynput==1.7.7
     # via ai-playground
+pyobjc-core==10.3.1
+    # via pyobjc-framework-applicationservices
+    # via pyobjc-framework-cocoa
+    # via pyobjc-framework-coretext
+    # via pyobjc-framework-quartz
+pyobjc-framework-applicationservices==10.3.1
+    # via pynput
+pyobjc-framework-cocoa==10.3.1
+    # via pyobjc-framework-applicationservices
+    # via pyobjc-framework-coretext
+    # via pyobjc-framework-quartz
+pyobjc-framework-coretext==10.3.1
+    # via pyobjc-framework-applicationservices
+pyobjc-framework-quartz==10.3.1
+    # via pynput
+    # via pyobjc-framework-applicationservices
+    # via pyobjc-framework-coretext
 pypdf==4.2.0
     # via unstructured-client
 pytest==8.3.1
@@ -231,8 +269,6 @@ python-iso639==2024.4.27
     # via unstructured
 python-magic==0.4.27
     # via unstructured
-python-xlib==0.33
-    # via pynput
 pyyaml==6.0.1
     # via huggingface-hub
     # via langchain
@@ -249,6 +285,7 @@ requests==2.32.3
     # via langchain
     # via langchain-community
     # via langsmith
+    # via opentelemetry-exporter-otlp-proto-http
     # via requests-toolbelt
     # via speechrecognition
     # via tiktoken
@@ -262,7 +299,6 @@ six==1.16.0
     # via langdetect
     # via pynput
     # via python-dateutil
-    # via python-xlib
     # via unstructured-client
 sniffio==1.3.1
     # via anthropic
@@ -299,6 +335,7 @@ typing-extensions==4.12.2
     # via emoji
     # via huggingface-hub
     # via openai
+    # via opentelemetry-sdk
     # via pydantic
     # via pydantic-core
     # via speechrecognition
@@ -317,6 +354,9 @@ urllib3==2.2.2
     # via requests
     # via unstructured-client
 wrapt==1.16.0
+    # via deprecated
     # via unstructured
 yarl==1.9.4
     # via aiohttp
+zipp==3.19.2
+    # via importlib-metadata

--- a/requirements.lock
+++ b/requirements.lock
@@ -51,6 +51,9 @@ dataclasses-json==0.6.7
     # via unstructured-client
 deepdiff==7.0.1
     # via unstructured-client
+deprecated==1.2.14
+    # via opentelemetry-api
+    # via opentelemetry-exporter-otlp-proto-http
 dill==0.3.8
     # via pylint
 distro==1.9.0
@@ -58,8 +61,6 @@ distro==1.9.0
     # via openai
 emoji==2.12.1
     # via unstructured
-evdev==1.7.1
-    # via pynput
 faiss-cpu==1.8.0.post1
     # via ai-playground
 filelock==3.15.4
@@ -72,6 +73,7 @@ frozenlist==1.4.1
 fsspec==2024.6.1
     # via huggingface-hub
 google-api-core==2.19.1
+    # via google-api-core
     # via google-cloud-speech
 google-auth==2.32.0
     # via ai-playground
@@ -82,14 +84,13 @@ google-cloud-speech==2.26.1
 googleapis-common-protos==1.63.2
     # via google-api-core
     # via grpcio-status
+    # via opentelemetry-exporter-otlp-proto-http
 graphviz==0.20.3
     # via ai-playground
-greenlet==3.0.3
-    # via sqlalchemy
 grpcio==1.65.1
     # via google-api-core
     # via grpcio-status
-grpcio-status==1.65.1
+grpcio-status==1.62.2
     # via google-api-core
 h11==0.14.0
     # via httpcore
@@ -107,6 +108,8 @@ idna==3.7
     # via requests
     # via unstructured-client
     # via yarl
+importlib-metadata==7.1.0
+    # via opentelemetry-api
 iniconfig==2.0.0
     # via pytest
 isort==5.13.2
@@ -172,6 +175,23 @@ numpy==1.26.4
 openai==1.35.13
     # via ai-playground
     # via langchain-openai
+opentelemetry-api==1.25.0
+    # via ai-playground
+    # via opentelemetry-exporter-otlp-proto-http
+    # via opentelemetry-sdk
+    # via opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.25.0
+    # via opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-http==1.25.0
+    # via ai-playground
+opentelemetry-proto==1.25.0
+    # via opentelemetry-exporter-otlp-proto-common
+    # via opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.25.0
+    # via ai-playground
+    # via opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.46b0
+    # via opentelemetry-sdk
 ordered-set==4.1.0
     # via deepdiff
 orjson==3.10.6
@@ -192,11 +212,12 @@ pluggy==1.5.0
 proto-plus==1.24.0
     # via google-api-core
     # via google-cloud-speech
-protobuf==5.27.2
+protobuf==4.25.3
     # via google-api-core
     # via google-cloud-speech
     # via googleapis-common-protos
     # via grpcio-status
+    # via opentelemetry-proto
     # via proto-plus
 psutil==6.0.0
     # via unstructured
@@ -219,6 +240,23 @@ pylint==3.2.5
     # via ai-playground
 pynput==1.7.7
     # via ai-playground
+pyobjc-core==10.3.1
+    # via pyobjc-framework-applicationservices
+    # via pyobjc-framework-cocoa
+    # via pyobjc-framework-coretext
+    # via pyobjc-framework-quartz
+pyobjc-framework-applicationservices==10.3.1
+    # via pynput
+pyobjc-framework-cocoa==10.3.1
+    # via pyobjc-framework-applicationservices
+    # via pyobjc-framework-coretext
+    # via pyobjc-framework-quartz
+pyobjc-framework-coretext==10.3.1
+    # via pyobjc-framework-applicationservices
+pyobjc-framework-quartz==10.3.1
+    # via pynput
+    # via pyobjc-framework-applicationservices
+    # via pyobjc-framework-coretext
 pypdf==4.2.0
     # via unstructured-client
 pytest==8.3.1
@@ -231,8 +269,6 @@ python-iso639==2024.4.27
     # via unstructured
 python-magic==0.4.27
     # via unstructured
-python-xlib==0.33
-    # via pynput
 pyyaml==6.0.1
     # via huggingface-hub
     # via langchain
@@ -249,6 +285,7 @@ requests==2.32.3
     # via langchain
     # via langchain-community
     # via langsmith
+    # via opentelemetry-exporter-otlp-proto-http
     # via requests-toolbelt
     # via speechrecognition
     # via tiktoken
@@ -262,7 +299,6 @@ six==1.16.0
     # via langdetect
     # via pynput
     # via python-dateutil
-    # via python-xlib
     # via unstructured-client
 sniffio==1.3.1
     # via anthropic
@@ -299,6 +335,7 @@ typing-extensions==4.12.2
     # via emoji
     # via huggingface-hub
     # via openai
+    # via opentelemetry-sdk
     # via pydantic
     # via pydantic-core
     # via speechrecognition
@@ -317,6 +354,9 @@ urllib3==2.2.2
     # via requests
     # via unstructured-client
 wrapt==1.16.0
+    # via deprecated
     # via unstructured
 yarl==1.9.4
     # via aiohttp
+zipp==3.19.2
+    # via importlib-metadata


### PR DESCRIPTION
going to see if I can augment this with the langtrace stuff, but this is mostly instrumentation around our abstractions/code.

An example trace [here](https://ui.honeycomb.io/replay/environments/ai-playground/datasets/ai_playground/result/tj4gyvQxpgs/trace/5fGYFY1AwWy?fields[]=s_name&fields[]=s_serviceName&fields[]=c_agent&fields[]=c_model&source=query&span=eb6b1bed499bdc24)

A couple of other changes I did along the way:

1. added a .env.secret.sample file to list the env vars we'll look for
2. added a `NoopModel` that does nothing.
3. added a `Model` parameter to Agent's `__init__`, so the model can be swapped out when instantiating the agent (in this case in `main.py`).

2&3 came in handy when testing all the otel stuff.



Another area for late night dorking around:

I'm not really happy with the boilerplate for instrumenting subclass methods (see all the tool files).  e.g. this line:

```
    @instrument("handle_tool_call", attributes={ "tool": "RgTool" })
```

It's nice to have them all using the same name (`handle_tool_call`) so we can do `=` filters in honeycomb instead of `contains`, and grouping events works better as well.  but it means we need a piece of additional context as well (the class name.)

Anyway, I'd prefer it get the tool name ambiently (maybe instead of `tool=RgTool` it would be `class=RgTool`), and drop the `attributes=`, but I'm not entirely sure how to do that yet.  at some point I'll also make the name parameter optional, and this line could become:

```
  @instrument
```

which seems like a win.