### PR TITLE
add pyright dep and start typechecking.  fix a lot of the errors, and ignore swaths of others

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@
 # Setup
 
 * Install [rye](https://rye.astral.sh/guide/basics/), make sure its activated and sync'ed and put in your startup script.
-* Create a new .env.secret file and add your secrets, especially:
+* Create a new `.env.secret` file and add your secrets, especially:
+  * `AI_MSN` (required - chooses the AI service+model+additional flags)
   * `ANTHROPIC_API_KEY` (for Claude)
   * `OPENAI_API_KEY` (optional, for GPT-4)
+  * There is `.env.secret.example` with an example of `AI_MSN` for use with claude.
 * Google Cloud setup (for speech-to-text support)
   * -> See below
 * Run `./setup.sh` to get started.

--- a/code-monkey/src/agents/agent.py
+++ b/code-monkey/src/agents/agent.py
@@ -1,14 +1,13 @@
 import os
-from typing import Set
+from typing import Set, Any
 from langgraph.prebuilt import create_react_agent
 from langchain_core.messages import HumanMessage, SystemMessage
-from langchain_core.language_models.chat_models import BaseChatModel
 
 from tools.utils import (
     ask_user,
     show_diff,
 )
-from constants import get_root_dir, get_artifacts_dir
+from constants import get_root_dir, get_artifacts_dir, get_agent_msn
 from models import MSN
 from .base_agent import BaseAgent
 from instrumentation import current_span, instrument
@@ -17,14 +16,16 @@ from langgraph.checkpoint.aiosqlite import AsyncSqliteSaver
 import logging
 
 class Agent(BaseAgent):
-    model: BaseChatModel
+    # trying to figure out how to type this.  It's not a BaseChatModel, it's a CompiledGraph from langgraph.graph, but that's not exported
+    model: Any
 
     config = {
         "configurable": {"thread_id": "abc123"},
     }
 
     @instrument("Agent.__init__", ["msn_str"])
-    def __init__(self, msn_str: str | None):
+    def __init__(self):
+        msn_str = get_agent_msn()
         msn = MSN.from_string(msn_str)
 
         # a checkpointer + the thread_id below gives the model a way to save its
@@ -42,8 +43,9 @@ class Agent(BaseAgent):
         pass
 
     @instrument("Agent.run_prompt", ["prompt"])
-    async def run_prompt(self, prompt: str):
-        print(f"Running prompt: {prompt}")
+    async def run_prompt(self, prompt: str) -> str:
+        logger = logging.getLogger(__name__)
+        logger.info(f"Running prompt: {prompt}")
 
         system = SystemMessage(content=self.get_system_prompt())
         msg = HumanMessage(content=self.prepare_prompt(prompt))
@@ -112,6 +114,7 @@ class Agent(BaseAgent):
         )
 
         # TODO(toshok) we aren't returning a result here, and likely should...
+        return ""  # just to quiet pyright
 
     @instrument("Agent.handle_completion")
     def handle_completion(self, modified_files: set) -> None:
@@ -125,7 +128,6 @@ class Agent(BaseAgent):
         if modified_files:
             for file in modified_files:
                 self.handle_modified_file(file)
-        return True
 
     @instrument("Agent.handle_modified_file", ["file"])
     def handle_modified_file(self, file: str) -> None:

--- a/code-monkey/src/agents/agents.py
+++ b/code-monkey/src/agents/agents.py
@@ -170,7 +170,7 @@ async def _run_agent_impl(agent_class: Type[Agent]):
     load_environment()
 
     # Initialize agent.
-    agent = agent_class(os.getenv("AI_MSN"))
+    agent = agent_class()
     agent.initialize()
 
     # Read prompt from .prompt.md file

--- a/code-monkey/src/agents/base_agent.py
+++ b/code-monkey/src/agents/base_agent.py
@@ -4,11 +4,11 @@ from typing import List
 
 
 class BaseAgent(ABC):
-    tools: List[BaseTool] = None
+    tools: List[BaseTool] = []
     SYSTEM_PROMPT = "You don't know what to do. Tell the user that they can't use you and must use an agent with a proper SYSTEM_PROMPT instead."
 
     @abstractmethod
-    def run_prompt(self, prompt: str) -> str:
+    async def run_prompt(self, prompt: str) -> str:
         pass
 
     def get_system_prompt(self) -> str:
@@ -19,5 +19,5 @@ class BaseAgent(ABC):
         pass
 
     @abstractmethod
-    def handle_completion(self, had_any_text: bool, modified_files: set) -> None:
+    def handle_completion(self, modified_files: set) -> None:
         pass

--- a/code-monkey/src/constants.py
+++ b/code-monkey/src/constants.py
@@ -20,5 +20,12 @@ def load_environment():
     load_dotenv(".env.secret")
 
 
+DEFAULT_MSN = "anthropic/claude-3-5-sonnet-20240620/anthropic-beta=max-tokens-3-5-sonnet-2024-07-15"
+
+
+def get_agent_msn():
+    return os.getenv("AI_MSN", DEFAULT_MSN)
+
+
 # Claude rate limit
 CLAUDE_RATE_LIMIT = 40000  # tokens per minute

--- a/code-monkey/src/main.py
+++ b/code-monkey/src/main.py
@@ -31,6 +31,10 @@ async def main(debug: bool = False) -> None:
         print("[bold red]No selection made. Exiting...[/bold red]")
         return
 
+    if isinstance(menu_entry_index, tuple):
+        print("[bold red]multi-selection not supported. Exiting...[/bold red]")
+        return
+
     agent_name, agent_class = agent_choices[menu_entry_index]
     console.print(f"[bold blue]Running {agent_name} agent...[/bold blue]")
 

--- a/code-monkey/src/main.py
+++ b/code-monkey/src/main.py
@@ -38,7 +38,7 @@ async def main(debug: bool = False) -> None:
     agent_name, agent_class = agent_choices[menu_entry_index]
     console.print(f"[bold blue]Running {agent_name} agent...[/bold blue]")
 
-    agent = agent_class(os.getenv("AI_MSN"))
+    agent = agent_class()
     agent.initialize()
 
     # Read prompt from .prompt.md file

--- a/code-monkey/src/models/msn.py
+++ b/code-monkey/src/models/msn.py
@@ -4,44 +4,44 @@ from langchain_core.language_models.chat_models import BaseChatModel
 
 from .registry import get_model_service_ctor, ChatModelConstructor
 
+
 # MSN is simile to a DSN ("Data Source Name" used to identify databases) to specify a model api service,
 # a model name/variant, and any extra flags.
 #
 # syntax is: service[/model[/flags]]
 #
-# where flags is a comma separated list of key[=value] pairs.  'key' on its own
-# is treated as a boolean True flag.
-
-
+# where flags is a comma separated list of key=value pairs
 @dataclass
 class MSN:
     chat_model_ctor: ChatModelConstructor
-    model_name: str | None
-    flags: Dict[str, str | bool] | None
+    model_name: str
+    flags: Dict[str, str]
 
     @classmethod
-    def from_string(cls, msn_str: str | None) -> Self:
-        if msn_str is None:
-            # our default
-            msn_str = "anthropic/"
+    def from_string(cls, msn_str: str) -> Self:
+        split_msn = msn_str.split("/", 2)
+        split_len = len(split_msn)
 
-        split_msn = msn_str.split("/")
+        if split_len < 2:
+            raise ValueError(
+                f"MSN must have at least a service and model name: {msn_str}"
+            )
 
         chat_model_ctor = get_model_service_ctor(split_msn[0])
-        model_name = split_msn[1] if len(split_msn) >= 2 else ""
-        flags = parse_flags(split_msn[2]) if len(split_msn) >= 3 else None
+        model_name = split_msn[1]
+        flags = parse_flags(split_msn[2], msn_str) if len(split_msn) >= 3 else {}
 
         return cls(chat_model_ctor, model_name, flags)
 
     def construct_model(self) -> BaseChatModel:
-        return self.chat_model_ctor(model_name=self.model_name, extra_flags=self.flags)
+        return self.chat_model_ctor(self.model_name, self.flags)
 
 
-def parse_flags(flags: str) -> Dict[str, str | bool]:
+def parse_flags(flags: str, source_msn_str: str) -> Dict[str, str]:
     # parse the flags into a dict based on k=v pairs (split on the first `=`.).
-    # if there's no '=', v will be True
     flags_dict = {}
     for flag in flags.split(","):
         k, v = flag.split("=", 1)
-        flags_dict[k] = v if v else True
+        if v is None:
+            raise ValueError(f"MSN flag {k} must have a value: {source_msn_str}")
     return flags_dict

--- a/code-monkey/src/models/registry.py
+++ b/code-monkey/src/models/registry.py
@@ -5,36 +5,34 @@ from langchain_openai import ChatOpenAI
 from langchain_ollama import ChatOllama
 from langchain_fireworks import ChatFireworks
 
-type ChatModelConstructor = Callable[
-    [str, Dict[str | None, str | bool] | None], BaseChatModel
-]
+type ChatModelConstructor = Callable[[str, Dict[str, str]], BaseChatModel]
 
 
-def construct_anthropic(
-    model_name: str, extra_flags: Dict[str | None, str | bool] | None
-) -> BaseChatModel:
-    if not model_name:
-        model_name = "claude-3-5-sonnet-20240620"
-    return ChatAnthropic(model_name=model_name, default_headers=extra_flags)
+def construct_anthropic(model_name: str, extra_flags: Dict[str, str]) -> BaseChatModel:
+    return ChatAnthropic(
+        model_name=model_name,
+        default_headers=extra_flags,
+        # for some reason these don't have default values in ChatAnthropic.__init__
+        timeout=None,
+        stop=None,
+        base_url=None,
+        api_key=None,
+    )
 
 
-def construct_openai(
-    model_name: str, extra_flags: Dict[str | None, str | bool] | None
-) -> BaseChatModel:
-    raise Exception("TODO(toshok): add model")
-    return ChatOpenAI(model_name=model_name, default_headers=extra_flags)
+def construct_openai(model_name: str, extra_flags: Dict[str, str]) -> BaseChatModel:
+    return ChatOpenAI(name=model_name, default_headers=extra_flags)
 
-
-def construct_ollama(
-    model_name: str, extra_flags: Dict[str | None, str | bool] | None
-) -> BaseChatModel:
+def construct_ollama(model_name: str, extra_flags: Dict[str, str]) -> BaseChatModel:
     return ChatOllama(model=model_name)
 
 
-def construct_fireworks(
-    model_name: str, extra_flags: Dict[str, str] | None
-) -> BaseChatModel:
-    return ChatFireworks(model=model_name, default_headers=extra_flags)
+def construct_fireworks(model_name: str, extra_flags: Dict[str, str]) -> BaseChatModel:
+    return ChatFireworks(
+        model=model_name,
+        # no default value for this one
+        stop_sequences=None,
+    )
 
 
 registry: Dict[str, ChatModelConstructor] = {

--- a/code-monkey/src/token_stats.py
+++ b/code-monkey/src/token_stats.py
@@ -2,7 +2,7 @@ import time
 from math import ceil
 from collections import deque, Counter
 from constants import CLAUDE_RATE_LIMIT
-from anthropic.types import ContentBlock
+from anthropic.types import ContentBlock, ToolUseBlock
 from typing import List
 from instrumentation import tracer
 
@@ -44,7 +44,7 @@ class TokenStats:
         type_label = "+".join(
             sorted(
                 [
-                    f"{m.type}.{m.name}" if hasattr(m, "name") and m.name else m.type
+                    f"{m.type}.{m.name}" if isinstance(m, ToolUseBlock) else m.type
                     for m in message_contents
                 ]
             )

--- a/code-monkey/src/tools/ca/ca_exports_tool.py
+++ b/code-monkey/src/tools/ca/ca_exports_tool.py
@@ -47,8 +47,7 @@ class CAExportsTool(CATool):
 
         exports_analysis = {}
         for file_path in all_files:
-            tree = self.parser.parse_file(file_path)
             module_name = get_module_name(file_path)
-            exports_analysis[module_name] = self.parser.get_exports(tree)
+            exports_analysis[module_name] = self.parser.get_exports(file_path)
 
         return json.dumps(exports_analysis, indent=1)

--- a/code-monkey/src/tools/ca/ca_imports_tool.py
+++ b/code-monkey/src/tools/ca/ca_imports_tool.py
@@ -49,8 +49,7 @@ class CAImportsTool(CATool):
 
         imports_analysis = {}
         for file_path in all_files:
-            tree = self.parser.parse_file(file_path)
             module_name = get_module_name(file_path)
-            imports_analysis[module_name] = self.parser.get_imports(tree)
+            imports_analysis[module_name] = self.parser.get_imports(file_path)
 
         return json.dumps(imports_analysis, indent=1)

--- a/code-monkey/src/tools/ca/ca_tool.py
+++ b/code-monkey/src/tools/ca/ca_tool.py
@@ -1,12 +1,12 @@
-from typing import Any, Optional
+from typing import Any
 from langchain_core.tools import BaseTool
 from deps import ASTParser
 
 
 class CATool(BaseTool):
-    parser: Optional[ASTParser] = None
+    parser: ASTParser
 
-    def __init__(self, **kwargs: Any) -> None:
+    def __init__(self, **kwargs: Any):
+        if "parser" not in kwargs:
+            kwargs["parser"] = ASTParser()
         super().__init__(**kwargs)
-        if self.parser is None:
-            self.parser = ASTParser()

--- a/code-monkey/src/tools/create_file_tool.py
+++ b/code-monkey/src/tools/create_file_tool.py
@@ -38,7 +38,8 @@ class CreateFileTool(IOTool):
         try:
             os.makedirs(os.path.dirname(file_path), exist_ok=True)
             with open(file_path, "x") as file:
-                file.write(content)
+                if content is not None:
+                    file.write(content)
             self.notify_file_modified(fname)
         except Exception:
             logging.error("Failed to create file: %s", file_path)

--- a/code-monkey/src/tools/run_test_tool.py
+++ b/code-monkey/src/tools/run_test_tool.py
@@ -106,7 +106,7 @@ class RunTestTool(BaseTool):
                 "cumpercall": cumpercall,
             }
 
-            return rv
+        return rv
 
     @instrument("Tool._run", ["fname"], attributes={"tool": "RunTestTool"})
     def _run(

--- a/code-monkey/src/tools/utils.py
+++ b/code-monkey/src/tools/utils.py
@@ -18,7 +18,7 @@ def ask_user(prompt: str) -> str:
     return input()
 
 
-def show_diff(original_file: str, modified_file: str) -> str:
+def show_diff(original_file: str, modified_file: str) -> None:
     logging.debug(f"Diffing {original_file} and {modified_file}")
     if os.path.exists(original_file) and os.path.exists(modified_file):
         subprocess.run(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,36 +6,36 @@ authors = [
     { name = "D. Seifert", email = "Domiii@users.noreply.github.com" }
 ]
 dependencies = [
-    "langchain==0.2.7",
-    "langchain-core>=0.2.7",
-    "langchain-community==0.2.7",
-    "langchain-anthropic>=0.1.20",
-    "langchain-ollama>=0.1.0",
-    "langchain-openai>=0.1.15",
-    "langchain-fireworks>=0.1.5",
-    "langgraph>=0.1.11",
     "aiosqlite>=0.20.0",
-    "openai>=1.35.13",
-    "opentelemetry-api>=1.25.0",
-    "opentelemetry-sdk>=1.25.0",
-    "opentelemetry-exporter-otlp-proto-http>=1.25.0",
-    "python-dotenv>=1.0.1",
-    "unstructured>=0.14.10",
+    "colorlog>=6.8.2",
     "faiss-cpu>=1.8.0.post1",
-    "tiktoken>=0.7.0",
-    "graphviz>=0.20.3",
-    "pylint>=3.2.5",
-    "pathspec>=0.12.1",
-    "pyaudio>=0.2.14",
-    "speechrecognition>=3.10.4",
     "google-auth>=2.32.0",
     "google-cloud-speech>=2.26.1",
-    "pytest>=8.3.1",
-    "pynput>=1.7.7",
+    "graphviz>=0.20.3",
+    "langchain-anthropic>=0.1.20",
+    "langchain-community>=0.2.7",
+    "langchain-core>=0.2.7",
+    "langchain-fireworks>=0.1.5",
+    "langchain-ollama>=0.1.0",
+    "langchain-openai>=0.1.15",
+    "langchain==0.2.7",
+    "langgraph>=0.1.11",
     "networkx>=3.3",
-    "colorlog>=6.8.2",
+    "openai>=1.35.13",
+    "opentelemetry-api>=1.25.0",
+    "opentelemetry-exporter-otlp-proto-http>=1.25.0",
+    "opentelemetry-sdk>=1.25.0",
+    "pathspec>=0.12.1",
+    "pyaudio>=0.2.14",
+    "pylint>=3.2.5",
+    "pynput>=1.7.7",
+    "pytest>=8.3.1",
+    "python-dotenv>=1.0.1",
     "rich>=13.7.1",
     "simple-term-menu>=1.6.4",
+    "speechrecognition>=3.10.4",
+    "tiktoken>=0.7.0",
+    "unstructured>=0.14.10",
 ]
 readme = "README.md"
 requires-python = ">= 3.8"
@@ -46,7 +46,9 @@ build-backend = "hatchling.build"
 
 [tool.rye]
 managed = true
-dev-dependencies = []
+dev-dependencies = [
+    "pyright>=1.1.373",
+]
 
 [tool.hatch.metadata]
 allow-direct-references = true
@@ -58,3 +60,7 @@ packages = ["src/ai_playground"]
 indent-style = "space"
 line-ending = "lf"
 quote-style = "double"
+
+
+[tool.rye.scripts]
+pyright = "pyright ./code-monkey/src/**/*.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,13 @@ indent-style = "space"
 line-ending = "lf"
 quote-style = "double"
 
+[tool.pyright]
+include = ["code-monkey/src/**/*.py"]
+ignore = [
+    "code-monkey/src/tools/get_dependencies_tool.py",
+    "code-monkey/src/audio/**/*.py",
+    "code-monkey/src/embeddings/**/*.py"
+]
 
 [tool.rye.scripts]
-pyright = "pyright ./code-monkey/src/**/*.py"
+typecheck = "pyright"

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -197,6 +197,8 @@ networkx==3.3
     # via ai-playground
 nltk==3.8.1
     # via unstructured
+nodeenv==1.9.1
+    # via pyright
 numpy==1.26.4
     # via faiss-cpu
     # via langchain
@@ -280,6 +282,7 @@ pynput==1.7.7
     # via ai-playground
 pypdf==4.3.1
     # via unstructured-client
+pyright==1.1.373
 pytest==8.3.2
     # via ai-playground
 python-dateutil==2.9.0.post0


### PR DESCRIPTION
Turns out python3 type hints are just that: hints.  they aren't checked at all outside code that actually looks at them (`pydantic`, etc.)

Add a dev dep on `pyright` and a script we can run using `rye run typecheck`